### PR TITLE
The order of x and y in t.test()

### DIFF
--- a/stat/first.html
+++ b/stat/first.html
@@ -415,7 +415,7 @@ y = with(sleep, extra[group==2])
 <p>すでに統計学を勉強した人は，<a href="ttest.html">t検定</a>をしてみましょう。<code>x</code> と <code>y</code> が独立な10個ずつの数だとした場合：</p>
 
 <pre>
-<code>&gt; t.test(x, y)
+<code>&gt; t.test(y, x)
 
 	Welch Two Sample t-test
 


### PR DESCRIPTION
`t.test()`の`x`と`y`の順序が出力と逆のようです。